### PR TITLE
AD-6 feat: mcp 연결 페이지 구현

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -71,9 +71,9 @@ export function Header() {
           to="/"
           className="flex items-center gap-3 hover:opacity-80 transition-opacity"
         >
-          <img src="/logo.svg" alt="ATLAS Logo" className="w-12 h-12" />
+          <img src="/logo.svg" alt="ATrina Logo" className="w-12 h-12" />
           <div className="flex items-center gap-1">
-            <span className="font-bold text-xl text-gray-900">ATLAS</span>
+            <span className="font-bold text-xl text-gray-900">ATrina</span>
             <span className="text-gray-900 text-base">
               : AI-Efficient-development
             </span>

--- a/src/pages/mcp/McpPage.tsx
+++ b/src/pages/mcp/McpPage.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { useRouter } from "@tanstack/react-router";
 import { ChevronDown, Copy } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
 
 type AssistantType = "Cursor" | "Claude" | "ChatGPT";
 
@@ -11,8 +12,10 @@ export default function McpPage() {
   const [selectedAssistant, setSelectedAssistant] =
     useState<AssistantType | null>(null);
   const [isAssistantDropdownOpen, setIsAssistantDropdownOpen] = useState(false);
+  const [showCommands, setShowCommands] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
+  const { toast } = useToast();
 
   // 외부 클릭 감지하여 드롭다운 닫기
   useEffect(() => {
@@ -41,15 +44,21 @@ export default function McpPage() {
 
   const handleCopyCommand = (command: string) => {
     navigator.clipboard.writeText(command);
-    // TODO: toast 알림 추가
+    toast({
+      title: "복사되었습니다!",
+    });
   };
 
   const handleComplete = () => {
-    router.navigate({ to: "/" });
+    if (selectedAssistant && !showCommands) {
+      setShowCommands(true);
+    } else {
+      router.navigate({ to: "/" });
+    }
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 p-12">
+    <div className="min-h-screen p-8 pt-6">
       <div className="max-w-7xl mx-auto">
         {/* 프로젝트명과 대시보드 버튼 */}
         <div className="flex items-center justify-between mb-8">
@@ -58,75 +67,76 @@ export default function McpPage() {
           </h1>
           <Button
             className="bg-black hover:bg-gray-800 text-white rounded-lg px-6 py-2"
-            onClick={() => router.navigate({ to: "/" })}
+            onClick={() => router.navigate({ to: "/task" })}
           >
-            대시보드로 돌아가기
+            태스크 관리
           </Button>
-        </div>
-
-        {/* AI Assistant 선택 드롭다운 */}
-        <div className="mb-8">
-          <div className="relative w-80" ref={dropdownRef}>
-            <button
-              onClick={() =>
-                setIsAssistantDropdownOpen(!isAssistantDropdownOpen)
-              }
-              className="w-full px-4 py-3 text-left bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors flex items-center justify-between"
-            >
-              <span className="text-gray-900 text-base">
-                {selectedAssistant || "사용할 AI assistant 선택하기"}
-              </span>
-              <ChevronDown className="w-5 h-5 text-gray-500" />
-            </button>
-
-            {isAssistantDropdownOpen && (
-              <div className="absolute z-10 w-full mt-2 bg-white border border-gray-300 rounded-lg shadow-lg overflow-hidden">
-                {ASSISTANTS.map((assistant) => (
-                  <button
-                    key={assistant}
-                    onClick={() => handleAssistantSelect(assistant)}
-                    className="w-full px-4 py-3 text-left hover:bg-gray-100 transition-colors text-gray-900 text-base"
-                  >
-                    {assistant}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
         </div>
 
         {/* 상태별 컨텐츠 영역 */}
         <div className="border border-gray-300 rounded-lg p-20 mb-8 min-h-[500px] flex flex-col items-center justify-center bg-white">
-          {!selectedAssistant ? (
-            // 초기 상태
+          {!showCommands ? (
+            // 초기 상태 - AI assistant 선택
             <div className="text-center">
-              <h2 className="text-2xl font-bold text-gray-900 mb-4">
+              <h2 className="text-2xl font-bold text-gray-900 mb-2">
                 프로젝트를 연동하세요
               </h2>
-              <p className="text-gray-600 mb-10 text-base">
+              <p className="text-gray-600 mb-6 text-base">
                 터미널에 복사할 명령어를 입력해주세요.
               </p>
-              <Button
-                className="bg-black hover:bg-gray-800 text-white rounded-lg px-10 py-3 text-base"
-                onClick={() => setIsAssistantDropdownOpen(true)}
-              >
-                MCP 연동하기
-              </Button>
+              <div className="relative w-80 mx-auto" ref={dropdownRef}>
+                <button
+                  onClick={() =>
+                    setIsAssistantDropdownOpen(!isAssistantDropdownOpen)
+                  }
+                  className="w-full px-4 py-3 text-left bg-black text-white border border-gray-300 rounded-lg hover:bg-gray-800 transition-colors flex items-center justify-between"
+                >
+                  <span className="text-base">
+                    {selectedAssistant || "사용할 AI assistant 선택하기"}
+                  </span>
+                  <ChevronDown className="w-5 h-5" />
+                </button>
+
+                {isAssistantDropdownOpen && (
+                  <div className="absolute z-10 w-full mt-2 bg-white border border-gray-300 rounded-lg shadow-lg overflow-hidden">
+                    {ASSISTANTS.map((assistant) => (
+                      <button
+                        key={assistant}
+                        onClick={() => handleAssistantSelect(assistant)}
+                        className="w-full px-4 py-3 text-left hover:bg-gray-100 transition-colors text-gray-900 text-base"
+                      >
+                        {assistant}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <div className="mt-2 h-6">
+                {selectedAssistant && (
+                  <p className="text-gray-600 text-sm">
+                    완료 버튼을 눌러 CLI 명령어를 확인하세요.
+                  </p>
+                )}
+              </div>
             </div>
           ) : (
             // CLI 명령어 표시
-            <div className="w-full max-w-3xl">
+            <div className="w-full max-w-2xl">
               <h2 className="text-xl font-semibold text-gray-900 mb-8">
                 다음 명령어를 터미널에서 실행하세요:
               </h2>
 
               <div className="space-y-4">
                 {/* 첫 번째 명령어 */}
-                <div className="bg-gray-900 text-white rounded-lg p-4 font-mono text-sm">
+                <div
+                  className="bg-gray-900 text-white rounded-lg p-4 font-mono text-sm cursor-pointer"
+                  onClick={() => handleCopyCommand("npm i -g @atrina/cli")}
+                >
                   <div className="flex items-center justify-between">
-                    <code>npm i -g @vooster/cli</code>
+                    <code>npm i -g @atrina/cli</code>
                     <button
-                      onClick={() => handleCopyCommand("npm i -g @vooster/cli")}
+                      onClick={() => handleCopyCommand("npm i -g @atrina/cli")}
                       className="ml-4 p-2 hover:bg-gray-800 rounded transition-colors"
                       aria-label="복사"
                     >
@@ -136,11 +146,14 @@ export default function McpPage() {
                 </div>
 
                 {/* 두 번째 명령어 */}
-                <div className="bg-gray-900 text-white rounded-lg p-4 font-mono text-sm">
+                <div
+                  className="bg-gray-900 text-white rounded-lg p-4 font-mono text-sm cursor-pointer"
+                  onClick={() => handleCopyCommand("atrina init HVN9")}
+                >
                   <div className="flex items-center justify-between">
-                    <code>vooster init HVN9</code>
+                    <code>atrina init HVN9</code>
                     <button
-                      onClick={() => handleCopyCommand("vooster init HVN9")}
+                      onClick={() => handleCopyCommand("atrina init HVN9")}
                       className="ml-4 p-2 hover:bg-gray-800 rounded transition-colors"
                       aria-label="복사"
                     >
@@ -150,8 +163,11 @@ export default function McpPage() {
                 </div>
               </div>
 
-              <div className="mt-8 text-base text-gray-600">
-                <p>위 명령어를 순서대로 실행한 후, 완료 버튼을 클릭하세요.</p>
+              <div className="mt-6 text-base text-gray-600 text-center">
+                <p>
+                  위 명령어를 터미널에서 순서대로 실행한 후, 완료 버튼을
+                  클릭하세요.
+                </p>
               </div>
             </div>
           )}
@@ -160,8 +176,9 @@ export default function McpPage() {
         {/* 완료 버튼 */}
         <div className="flex justify-end">
           <Button
-            className="bg-black hover:bg-gray-800 text-white rounded-lg px-8 py-2"
+            className="bg-black hover:bg-gray-800 text-white rounded-lg px-8 py-2 disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={handleComplete}
+            disabled={!selectedAssistant}
           >
             완료
           </Button>

--- a/src/pages/mcp/McpPage.tsx
+++ b/src/pages/mcp/McpPage.tsx
@@ -1,8 +1,172 @@
+import { useState, useRef, useEffect } from "react";
+import { useRouter } from "@tanstack/react-router";
+import { ChevronDown, Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type AssistantType = "Cursor" | "Claude" | "ChatGPT";
+
+const ASSISTANTS: AssistantType[] = ["Cursor", "Claude", "ChatGPT"];
+
 export default function McpPage() {
+  const [selectedAssistant, setSelectedAssistant] =
+    useState<AssistantType | null>(null);
+  const [isAssistantDropdownOpen, setIsAssistantDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
+
+  // 외부 클릭 감지하여 드롭다운 닫기
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsAssistantDropdownOpen(false);
+      }
+    }
+
+    if (isAssistantDropdownOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isAssistantDropdownOpen]);
+
+  const handleAssistantSelect = (assistant: AssistantType) => {
+    setSelectedAssistant(assistant);
+    setIsAssistantDropdownOpen(false);
+  };
+
+  const handleCopyCommand = (command: string) => {
+    navigator.clipboard.writeText(command);
+    // TODO: toast 알림 추가
+  };
+
+  const handleComplete = () => {
+    router.navigate({ to: "/" });
+  };
+
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">MCP 연동</h1>
-      <p className="mt-4 text-gray-600">MCP 연동 페이지입니다.</p>
+    <div className="min-h-screen bg-gray-50 p-12">
+      <div className="max-w-7xl mx-auto">
+        {/* 프로젝트명과 대시보드 버튼 */}
+        <div className="flex items-center justify-between mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">
+            종합설계프로젝트 1팀
+          </h1>
+          <Button
+            className="bg-black hover:bg-gray-800 text-white rounded-lg px-6 py-2"
+            onClick={() => router.navigate({ to: "/" })}
+          >
+            대시보드로 돌아가기
+          </Button>
+        </div>
+
+        {/* AI Assistant 선택 드롭다운 */}
+        <div className="mb-8">
+          <div className="relative w-80" ref={dropdownRef}>
+            <button
+              onClick={() =>
+                setIsAssistantDropdownOpen(!isAssistantDropdownOpen)
+              }
+              className="w-full px-4 py-3 text-left bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors flex items-center justify-between"
+            >
+              <span className="text-gray-900 text-base">
+                {selectedAssistant || "사용할 AI assistant 선택하기"}
+              </span>
+              <ChevronDown className="w-5 h-5 text-gray-500" />
+            </button>
+
+            {isAssistantDropdownOpen && (
+              <div className="absolute z-10 w-full mt-2 bg-white border border-gray-300 rounded-lg shadow-lg overflow-hidden">
+                {ASSISTANTS.map((assistant) => (
+                  <button
+                    key={assistant}
+                    onClick={() => handleAssistantSelect(assistant)}
+                    className="w-full px-4 py-3 text-left hover:bg-gray-100 transition-colors text-gray-900 text-base"
+                  >
+                    {assistant}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* 상태별 컨텐츠 영역 */}
+        <div className="border border-gray-300 rounded-lg p-20 mb-8 min-h-[500px] flex flex-col items-center justify-center bg-white">
+          {!selectedAssistant ? (
+            // 초기 상태
+            <div className="text-center">
+              <h2 className="text-2xl font-bold text-gray-900 mb-4">
+                프로젝트를 연동하세요
+              </h2>
+              <p className="text-gray-600 mb-10 text-base">
+                터미널에 복사할 명령어를 입력해주세요.
+              </p>
+              <Button
+                className="bg-black hover:bg-gray-800 text-white rounded-lg px-10 py-3 text-base"
+                onClick={() => setIsAssistantDropdownOpen(true)}
+              >
+                MCP 연동하기
+              </Button>
+            </div>
+          ) : (
+            // CLI 명령어 표시
+            <div className="w-full max-w-3xl">
+              <h2 className="text-xl font-semibold text-gray-900 mb-8">
+                다음 명령어를 터미널에서 실행하세요:
+              </h2>
+
+              <div className="space-y-4">
+                {/* 첫 번째 명령어 */}
+                <div className="bg-gray-900 text-white rounded-lg p-4 font-mono text-sm">
+                  <div className="flex items-center justify-between">
+                    <code>npm i -g @vooster/cli</code>
+                    <button
+                      onClick={() => handleCopyCommand("npm i -g @vooster/cli")}
+                      className="ml-4 p-2 hover:bg-gray-800 rounded transition-colors"
+                      aria-label="복사"
+                    >
+                      <Copy className="w-4 h-4" />
+                    </button>
+                  </div>
+                </div>
+
+                {/* 두 번째 명령어 */}
+                <div className="bg-gray-900 text-white rounded-lg p-4 font-mono text-sm">
+                  <div className="flex items-center justify-between">
+                    <code>vooster init HVN9</code>
+                    <button
+                      onClick={() => handleCopyCommand("vooster init HVN9")}
+                      className="ml-4 p-2 hover:bg-gray-800 rounded transition-colors"
+                      aria-label="복사"
+                    >
+                      <Copy className="w-4 h-4" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-8 text-base text-gray-600">
+                <p>위 명령어를 순서대로 실행한 후, 완료 버튼을 클릭하세요.</p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* 완료 버튼 */}
+        <div className="flex justify-end">
+          <Button
+            className="bg-black hover:bg-gray-800 text-white rounded-lg px-8 py-2"
+            onClick={handleComplete}
+          >
+            완료
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/pages/mcp/McpPage.tsx
+++ b/src/pages/mcp/McpPage.tsx
@@ -1,44 +1,25 @@
-import { useState, useRef, useEffect } from "react";
+import { useState } from "react";
 import { useRouter } from "@tanstack/react-router";
-import { ChevronDown, Copy } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
-
-type AssistantType = "Cursor" | "Claude" | "ChatGPT";
-
-const ASSISTANTS: AssistantType[] = ["Cursor", "Claude", "ChatGPT"];
+import InitialView from "./components/InitialView";
+import CommandView from "./components/CommandView";
+import type { AssistantType } from "./types";
 
 export default function McpPage() {
   const [selectedAssistant, setSelectedAssistant] =
     useState<AssistantType | null>(null);
   const [isAssistantDropdownOpen, setIsAssistantDropdownOpen] = useState(false);
   const [showCommands, setShowCommands] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const { toast } = useToast();
 
   // TODO: API에서 프로젝트 정보 가져오기
   const projectName = "종합설계프로젝트 1팀";
 
-  // 외부 클릭 감지하여 드롭다운 닫기
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
-      ) {
-        setIsAssistantDropdownOpen(false);
-      }
-    }
-
-    if (isAssistantDropdownOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [isAssistantDropdownOpen]);
+  const handleDropdownToggle = () => {
+    setIsAssistantDropdownOpen(!isAssistantDropdownOpen);
+  };
 
   const handleAssistantSelect = (assistant: AssistantType) => {
     setSelectedAssistant(assistant);
@@ -49,6 +30,7 @@ export default function McpPage() {
     navigator.clipboard.writeText(command);
     toast({
       title: "복사되었습니다!",
+      duration: 3000,
     });
   };
 
@@ -77,100 +59,14 @@ export default function McpPage() {
         {/* 상태별 컨텐츠 영역 */}
         <div className="border border-gray-300 rounded-lg p-20 mb-8 min-h-[500px] flex flex-col items-center justify-center bg-white">
           {!showCommands ? (
-            // 초기 상태 - AI assistant 선택
-            <div className="text-center">
-              <h2 className="text-2xl font-bold text-gray-900 mb-2">
-                프로젝트를 연동하세요
-              </h2>
-              <p className="text-gray-600 mb-6 text-base">
-                터미널에 복사할 명령어를 입력해주세요.
-              </p>
-              <div className="relative w-80 mx-auto" ref={dropdownRef}>
-                <button
-                  onClick={() =>
-                    setIsAssistantDropdownOpen(!isAssistantDropdownOpen)
-                  }
-                  className="w-full px-4 py-3 text-left bg-black text-white border border-gray-300 rounded-lg hover:bg-gray-800 transition-colors flex items-center justify-between"
-                >
-                  <span className="text-base">
-                    {selectedAssistant || "사용할 AI assistant 선택하기"}
-                  </span>
-                  <ChevronDown className="w-5 h-5" />
-                </button>
-
-                {isAssistantDropdownOpen && (
-                  <div className="absolute z-10 w-full mt-2 bg-white border border-gray-300 rounded-lg shadow-lg overflow-hidden">
-                    {ASSISTANTS.map((assistant) => (
-                      <button
-                        key={assistant}
-                        onClick={() => handleAssistantSelect(assistant)}
-                        className="w-full px-4 py-3 text-left hover:bg-gray-100 transition-colors text-gray-900 text-base"
-                      >
-                        {assistant}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              <div className="mt-2 h-6">
-                {selectedAssistant && (
-                  <p className="text-gray-600 text-sm">
-                    완료 버튼을 눌러 CLI 명령어를 확인하세요.
-                  </p>
-                )}
-              </div>
-            </div>
+            <InitialView
+              selectedAssistant={selectedAssistant}
+              isDropdownOpen={isAssistantDropdownOpen}
+              onDropdownToggle={handleDropdownToggle}
+              onAssistantSelect={handleAssistantSelect}
+            />
           ) : (
-            // CLI 명령어 표시
-            <div className="w-full max-w-2xl">
-              <h2 className="text-xl font-semibold text-gray-900 mb-8">
-                다음 명령어를 터미널에서 실행하세요:
-              </h2>
-
-              <div className="space-y-4">
-                {/* 첫 번째 명령어 */}
-                <div
-                  className="bg-gray-900 text-white rounded-lg p-4 font-mono text-sm cursor-pointer"
-                  onClick={() => handleCopyCommand("npm i -g @atrina/cli")}
-                >
-                  <div className="flex items-center justify-between">
-                    <code>npm i -g @atrina/cli</code>
-                    <button
-                      onClick={() => handleCopyCommand("npm i -g @atrina/cli")}
-                      className="ml-4 p-2 hover:bg-gray-800 rounded transition-colors"
-                      aria-label="복사"
-                    >
-                      <Copy className="w-4 h-4" />
-                    </button>
-                  </div>
-                </div>
-
-                {/* 두 번째 명령어 */}
-                <div
-                  className="bg-gray-900 text-white rounded-lg p-4 font-mono text-sm cursor-pointer"
-                  onClick={() => handleCopyCommand("atrina init HVN9")}
-                >
-                  <div className="flex items-center justify-between">
-                    <code>atrina init HVN9</code>
-                    <button
-                      onClick={() => handleCopyCommand("atrina init HVN9")}
-                      className="ml-4 p-2 hover:bg-gray-800 rounded transition-colors"
-                      aria-label="복사"
-                    >
-                      <Copy className="w-4 h-4" />
-                    </button>
-                  </div>
-                </div>
-              </div>
-
-              <div className="mt-6 text-base text-gray-600 text-center">
-                <p>
-                  위 명령어를 터미널에서 순서대로 실행한 후, 완료 버튼을
-                  클릭하세요.
-                </p>
-              </div>
-            </div>
+            <CommandView onCopyCommand={handleCopyCommand} />
           )}
         </div>
 

--- a/src/pages/mcp/McpPage.tsx
+++ b/src/pages/mcp/McpPage.tsx
@@ -17,6 +17,9 @@ export default function McpPage() {
   const router = useRouter();
   const { toast } = useToast();
 
+  // TODO: API에서 프로젝트 정보 가져오기
+  const projectName = "종합설계프로젝트 1팀";
+
   // 외부 클릭 감지하여 드롭다운 닫기
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -62,9 +65,7 @@ export default function McpPage() {
       <div className="max-w-7xl mx-auto">
         {/* 프로젝트명과 대시보드 버튼 */}
         <div className="flex items-center justify-between mb-8">
-          <h1 className="text-3xl font-bold text-gray-900">
-            종합설계프로젝트 1팀
-          </h1>
+          <h1 className="text-3xl font-bold text-gray-900">{projectName}</h1>
           <Button
             className="bg-black hover:bg-gray-800 text-white rounded-lg px-6 py-2"
             onClick={() => router.navigate({ to: "/task" })}

--- a/src/pages/mcp/components/AssistantDropdown.tsx
+++ b/src/pages/mcp/components/AssistantDropdown.tsx
@@ -1,0 +1,69 @@
+import { useRef, useEffect } from "react";
+import { ChevronDown } from "lucide-react";
+import { ASSISTANTS, type AssistantType } from "../types";
+
+interface AssistantDropdownProps {
+  selectedAssistant: AssistantType | null;
+  isOpen: boolean;
+  onToggle: () => void;
+  onSelect: (assistant: AssistantType) => void;
+}
+
+export default function AssistantDropdown({
+  selectedAssistant,
+  isOpen,
+  onToggle,
+  onSelect,
+}: AssistantDropdownProps) {
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // 외부 클릭 감지하여 드롭다운 닫기
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        if (isOpen) {
+          onToggle();
+        }
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen, onToggle]);
+
+  return (
+    <div className="relative w-80 mx-auto" ref={dropdownRef}>
+      <button
+        onClick={onToggle}
+        className="w-full px-4 py-3 text-left bg-black text-white border border-gray-300 rounded-lg hover:bg-gray-800 transition-colors flex items-center justify-between"
+      >
+        <span className="text-base">
+          {selectedAssistant || "사용할 AI assistant 선택하기"}
+        </span>
+        <ChevronDown className="w-5 h-5" />
+      </button>
+
+      {isOpen && (
+        <div className="absolute z-10 w-full mt-2 bg-white border border-gray-300 rounded-lg shadow-lg overflow-hidden">
+          {ASSISTANTS.map((assistant) => (
+            <button
+              key={assistant}
+              onClick={() => onSelect(assistant)}
+              className="w-full px-4 py-3 text-left hover:bg-gray-100 transition-colors text-gray-900 text-base"
+            >
+              {assistant}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/mcp/components/CommandView.tsx
+++ b/src/pages/mcp/components/CommandView.tsx
@@ -1,0 +1,50 @@
+import { Copy } from "lucide-react";
+
+interface CommandViewProps {
+  onCopyCommand: (command: string) => void;
+}
+
+const COMMANDS = [
+  { text: "npm i -g @atrina/cli", label: "Atrina CLI 설치" },
+  { text: "atrina init HVN9", label: "프로젝트 초기화" },
+];
+
+export default function CommandView({ onCopyCommand }: CommandViewProps) {
+  return (
+    <div className="w-full max-w-2xl">
+      <h2 className="text-xl font-semibold text-gray-900 mb-8">
+        다음 명령어를 터미널에서 실행하세요:
+      </h2>
+
+      <div className="space-y-4">
+        {COMMANDS.map((cmd) => (
+          <div
+            key={cmd.text}
+            className="bg-gray-900 text-white rounded-lg p-4 font-mono text-sm cursor-pointer"
+            onClick={() => onCopyCommand(cmd.text)}
+          >
+            <div className="flex items-center justify-between">
+              <code>{cmd.text}</code>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCopyCommand(cmd.text);
+                }}
+                className="ml-4 p-2 hover:bg-gray-800 rounded transition-colors"
+                aria-label="복사"
+              >
+                <Copy className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-6 text-base text-gray-600 text-center">
+        <p>
+          위 명령어를 터미널에서 순서대로 실행한 후, 완료 버튼을 클릭하세요.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/mcp/components/InitialView.tsx
+++ b/src/pages/mcp/components/InitialView.tsx
@@ -1,0 +1,42 @@
+import AssistantDropdown from "./AssistantDropdown";
+import type { AssistantType } from "../types";
+
+interface InitialViewProps {
+  selectedAssistant: AssistantType | null;
+  isDropdownOpen: boolean;
+  onDropdownToggle: () => void;
+  onAssistantSelect: (assistant: AssistantType) => void;
+}
+
+export default function InitialView({
+  selectedAssistant,
+  isDropdownOpen,
+  onDropdownToggle,
+  onAssistantSelect,
+}: InitialViewProps) {
+  return (
+    <div className="text-center">
+      <h2 className="text-2xl font-bold text-gray-900 mb-2">
+        프로젝트를 연동하세요
+      </h2>
+      <p className="text-gray-600 mb-6 text-base">
+        사용할 AI assistant를 선택하세요.
+      </p>
+
+      <AssistantDropdown
+        selectedAssistant={selectedAssistant}
+        isOpen={isDropdownOpen}
+        onToggle={onDropdownToggle}
+        onSelect={onAssistantSelect}
+      />
+
+      <div className="mt-2 h-6">
+        {selectedAssistant && (
+          <p className="text-gray-600 text-sm">
+            완료 버튼을 눌러 CLI 명령어를 확인하세요.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/mcp/types.ts
+++ b/src/pages/mcp/types.ts
@@ -1,0 +1,3 @@
+export type AssistantType = "Cursor" | "Claude" | "ChatGPT";
+
+export const ASSISTANTS: AssistantType[] = ["Cursor", "Claude", "ChatGPT"];

--- a/src/pages/task/TaskPage.tsx
+++ b/src/pages/task/TaskPage.tsx
@@ -14,7 +14,7 @@ export default function TaskPage() {
   const [searchQuery, setSearchQuery] = useState("");
 
   // 프로젝트 정보
-  const PROJECT_NAME = "4Y3M 프로젝트";
+  const PROJECT_ID = "4Y3M";
 
   // 태스크 목록 불러오기
   useEffect(() => {
@@ -253,7 +253,7 @@ export default function TaskPage() {
           isOpen={isDetailModalOpen}
           onClose={() => setIsDetailModalOpen(false)}
           task={selectedTask}
-          projectName={PROJECT_NAME}
+          projectId={PROJECT_ID}
           onUpdate={handleUpdateTaskContent}
           onStartTask={handleStartTask}
         />

--- a/src/pages/task/components/TaskDetailModal/TaskCommandView.tsx
+++ b/src/pages/task/components/TaskDetailModal/TaskCommandView.tsx
@@ -7,19 +7,19 @@ import type { Task } from "../../../../types/task";
 
 interface TaskCommandViewProps {
   task: Task;
-  projectName: string;
+  projectId: string;
   onComplete: () => void;
   onLater: () => void;
 }
 
 export default function TaskCommandView({
   task,
-  projectName,
+  projectId,
   onComplete,
   onLater,
 }: TaskCommandViewProps) {
   const { toast } = useToast();
-  const command = `vooster-ai를 사용해서 ${projectName}의 ${task.taskCode || task.id} 작업 수행하라`;
+  const command = `vooster-ai를 사용해서 ${projectId}의 ${task.taskCode || task.id} 작업 수행하라`;
 
   const handleCopy = async () => {
     try {

--- a/src/pages/task/components/TaskDetailModal/TaskCommandView.tsx
+++ b/src/pages/task/components/TaskDetailModal/TaskCommandView.tsx
@@ -26,14 +26,14 @@ export default function TaskCommandView({
       await navigator.clipboard.writeText(command);
       toast({
         title: "복사되었습니다!",
-        duration: 5000,
+        duration: 3000,
       });
     } catch (error) {
       console.error("클립보드 복사 실패:", error);
       toast({
         title: "복사 실패",
         variant: "destructive",
-        duration: 5000,
+        duration: 3000,
       });
     }
   };

--- a/src/pages/task/components/TaskDetailModal/TaskDetailModal.tsx
+++ b/src/pages/task/components/TaskDetailModal/TaskDetailModal.tsx
@@ -8,7 +8,7 @@ interface TaskDetailModalProps {
   isOpen: boolean;
   onClose: () => void;
   task: Task;
-  projectName: string;
+  projectId: string;
   onUpdate: (taskId: string, content: string) => void;
   onStartTask: (taskId: string) => void;
 }
@@ -17,7 +17,7 @@ export default function TaskDetailModal({
   isOpen,
   onClose,
   task,
-  projectName,
+  projectId,
   onUpdate,
   onStartTask,
 }: TaskDetailModalProps) {
@@ -57,7 +57,7 @@ export default function TaskDetailModal({
         ) : (
           <TaskCommandView
             task={task}
-            projectName={projectName}
+            projectId={projectId}
             onComplete={handleComplete}
             onLater={handleLater}
           />


### PR DESCRIPTION
### 1️⃣ PR 타입 (PR Type)

<!-- 해당하는 곳에 `x`를 표시해주세요. -->

- [x] ✨ feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [ ] 🎨 style: 코드 스타일 변경 (포맷팅, 세미콜론 추가 등)
- [ ] chore: 빌드 스크립트 수정, 패키지 매니저 설정 변경 등

### 2️⃣ 변경 사항 (Changes)

- MCP 연동 페이지 구현 및 서비스명 변경 (ATLAS → ATrina)

### 3️⃣ 관련 이슈 (Related Issues)

- 관련 이슈 번호를 작성해주세요.
- #6 

### 4️⃣ 코드 설명 (Description)

- 주요 변경 사항
1. MCP 연동 페이지 구현

  - AI Assistant 선택 기능 (Cursor, Claude, ChatGPT)
  - 드롭다운 UI 및 외부 클릭 감지 기능
  - CLI 명령어 표시 화면 (npm i -g @atrina/cli, atrina init)
  - 복사 버튼 클릭 시 토스트 알림 (3초)
  - 단계별 UI 전환 (초기 상태 → 명령어 표시 → 완료)

2. 컴포넌트 구조화

  - `src/pages/mcp/types.ts `- 타입 정의
  - `src/pages/mcp/components/AssistantDropdown.tsx` - AI Assistant 선택 드롭다운
  - `src/pages/mcp/components/InitialView.tsx` - 초기 화면
  - `src/pages/mcp/components/CommandView.tsx `- CLI 명령어 표시 화면

3. Task 페이지 리팩토링

  - projectName → projectId 변경
  - TaskDetailModal 및 TaskCommandView props 업데이트
  - 명령어 생성 로직 개선

4. 서비스이름 변경

  - Header 컴포넌트의 ATLAS → ATrina 변경

### 5️⃣ 스크린샷 (Screenshots)
<img width="1470" height="879" alt="스크린샷 2025-11-04 오후 3 49 22" src="https://github.com/user-attachments/assets/45375536-94ad-4082-b19a-6bf870d2cbfd" />
<img width="1470" height="877" alt="스크린샷 2025-11-04 오후 3 49 34" src="https://github.com/user-attachments/assets/0fe4c20b-4284-4471-8b73-500914fc5050" />
