### PR TITLE
AD-8 feat: header 반응형 구현

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { Link, useRouter } from "@tanstack/react-router";
-import { Menu } from "lucide-react";
+import { Menu, X } from "lucide-react";
 
 // 네비게이션 메뉴 데이터
 const NAV_ITEMS = [
@@ -107,9 +107,9 @@ export function Header() {
               <Menu className="w-5 h-5 tablet:w-6 tablet:h-6 text-gray-700" />
             </button>
 
-            {/* 드롭다운 메뉴 */}
+            {/* 데스크탑 드롭다운 메뉴 (> 812px) */}
             {isDropdownOpen && (
-              <div className="absolute right-0 mt-3 w-56 bg-white rounded-lg shadow-xl border border-gray-200 py-2 px-2 z-[60] animate-in fade-in slide-in-from-top-2 duration-200">
+              <div className="hidden tablet:block absolute right-0 mt-3 w-64 bg-white rounded-lg shadow-xl border border-gray-200 py-2 px-2 z-[60] animate-in fade-in slide-in-from-top-2 duration-200">
                 {DROPDOWN_ITEMS.map((item) => (
                   <button
                     key={item.path}
@@ -126,6 +126,81 @@ export function Header() {
               </div>
             )}
           </div>
+        </div>
+      </div>
+
+      {/* 모바일 오버레이 (≤ 812px) */}
+      {isDropdownOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 z-40 tablet:hidden"
+          onClick={() => setIsDropdownOpen(false)}
+        />
+      )}
+
+      {/* 모바일 슬라이드 사이드바 (≤ 812px) */}
+      <div
+        className={`
+          fixed inset-y-0 right-0 w-80 bg-white shadow-2xl z-50
+          transform transition-transform duration-300 ease-in-out
+          ${isDropdownOpen ? "translate-x-0" : "translate-x-full"}
+          tablet:hidden
+        `}
+      >
+        {/* 헤더 */}
+        <div className="flex items-center justify-between p-6 border-b border-gray-200">
+          <span className="font-bold text-lg text-gray-900">메뉴</span>
+          <button
+            onClick={() => setIsDropdownOpen(false)}
+            className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+            aria-label="닫기"
+          >
+            <X className="w-6 h-6 text-gray-700" />
+          </button>
+        </div>
+
+        {/* 메인 네비게이션 */}
+        <nav className="p-4">
+          <div className="mb-2 px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+            메인 메뉴
+          </div>
+          {NAV_ITEMS.map((item) => (
+            <button
+              key={item.path}
+              onClick={() => handleDropdownItemClick(item.path)}
+              className="w-full text-left px-4 py-3 hover:bg-gray-100 rounded-lg font-medium text-gray-900 transition-colors"
+            >
+              {item.label}
+            </button>
+          ))}
+        </nav>
+
+        {/* 구분선 */}
+        <div className="border-t border-gray-200 mx-4"></div>
+
+        {/* 설정 메뉴 */}
+        <div className="p-4">
+          <div className="mb-2 px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+            설정
+          </div>
+          {DROPDOWN_ITEMS.map((item) => (
+            <button
+              key={item.path}
+              onClick={() => handleDropdownItemClick(item.path)}
+              className="w-full text-left px-4 py-2.5 hover:bg-gray-100 rounded-lg text-gray-700 transition-colors"
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+
+        {/* 로그아웃 (하단 고정) */}
+        <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-gray-200 bg-white">
+          <button
+            onClick={handleLogout}
+            className="w-full px-4 py-3 bg-red-50 hover:bg-red-100 text-red-600 rounded-lg font-medium transition-colors"
+          >
+            로그아웃
+          </button>
         </div>
       </div>
     </header>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -161,7 +161,7 @@ export function Header() {
         {/* 메인 네비게이션 */}
         <nav className="p-4">
           <div className="mb-2 px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-            메인 메뉴
+            프로젝트 메뉴
           </div>
           {NAV_ITEMS.map((item) => (
             <button

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -65,25 +65,31 @@ export function Header() {
 
   return (
     <header className="sticky top-0 z-50 bg-white border-b border-gray-200 shadow-sm">
-      <div className="flex items-center justify-between px-8 py-3">
+      <div className="flex items-center justify-between px-4 md:px-8 py-3">
         {/* 로고 영역 */}
         <Link
           to="/"
-          className="flex items-center gap-3 hover:opacity-80 transition-opacity"
+          className="flex items-center gap-2 md:gap-3 hover:opacity-80 transition-opacity"
         >
-          <img src="/logo.svg" alt="ATrina Logo" className="w-12 h-12" />
+          <img
+            src="/logo.svg"
+            alt="ATrina Logo"
+            className="w-10 h-10 md:w-12 md:h-12"
+          />
           <div className="flex items-center gap-1">
-            <span className="font-bold text-xl text-gray-900">ATrina</span>
-            <span className="text-gray-900 text-base">
+            <span className="font-bold text-lg md:text-xl text-gray-900">
+              ATrina
+            </span>
+            <span className="hidden sm:inline text-sm md:text-base text-gray-900">
               : AI-Efficient-development
             </span>
           </div>
         </Link>
 
         {/* 네비게이션 + 햄버거 메뉴 그룹 */}
-        <div className="flex items-center gap-12">
-          {/* 중앙 네비게이션 */}
-          <nav className="flex items-center gap-8">
+        <div className="flex items-center gap-6 tablet:gap-12">
+          {/* 중앙 네비게이션 - 812px 이상에서만 표시 */}
+          <nav className="hidden tablet:flex items-center gap-6 xl:gap-8">
             {NAV_ITEMS.map((item) => (
               <Link key={item.path} to={item.path} className={STYLES.navLink}>
                 {item.label}
@@ -98,7 +104,7 @@ export function Header() {
               className="p-2 hover:bg-gray-200 rounded-lg transition-colors"
               aria-label="메뉴"
             >
-              <Menu className="w-6 h-6 text-gray-700" />
+              <Menu className="w-5 h-5 tablet:w-6 tablet:h-6 text-gray-700" />
             </button>
 
             {/* 드롭다운 메뉴 */}

--- a/src/pages/mcp/McpPage.tsx
+++ b/src/pages/mcp/McpPage.tsx
@@ -38,12 +38,12 @@ export default function McpPage() {
     if (selectedAssistant && !showCommands) {
       setShowCommands(true);
     } else {
-      router.navigate({ to: "/" });
+      router.navigate({ to: "/task" });
     }
   };
 
   return (
-    <div className="min-h-screen p-8 pt-6">
+    <div className="min-h-screen p-8 pt-8">
       <div className="max-w-7xl mx-auto">
         {/* 프로젝트명과 대시보드 버튼 */}
         <div className="flex items-center justify-between mb-8">

--- a/src/pages/mcp/components/CommandView.tsx
+++ b/src/pages/mcp/components/CommandView.tsx
@@ -20,7 +20,7 @@ export default function CommandView({ onCopyCommand }: CommandViewProps) {
         {COMMANDS.map((cmd) => (
           <div
             key={cmd.text}
-            className="bg-gray-900 text-white rounded-lg p-4 font-mono text-sm cursor-pointer"
+            className="bg-gray-900 text-white rounded-lg p-4 font-mono text-sm cursor-pointer hover:bg-gray-800 transition-colors"
             onClick={() => onCopyCommand(cmd.text)}
           >
             <div className="flex items-center justify-between">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,9 @@ export default {
     content: ["./index.html", "./src/**/*.{ts,tsx}"],
     theme: {
         extend: {
+            screens: {
+                tablet: "813px",
+            },
             colors: {
                 primary: "#7871FE",
                 secondary: "#4C2EFF",


### PR DESCRIPTION
### 1️⃣ PR 타입 (PR Type)

<!-- 해당하는 곳에 `x`를 표시해주세요. -->

- [ ] ✨ feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [x] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [ ] 🎨 style: 코드 스타일 변경 (포맷팅, 세미콜론 추가 등)
- [ ] chore: 빌드 스크립트 수정, 패키지 매니저 설정 변경 등

### 2️⃣ 변경 사항 (Changes)

-  Header 반응형 UI 개선 (812px 기준 슬라이드 사이드바)

### 3️⃣ 관련 이슈 (Related Issues)

- 관련 이슈 번호를 작성해주세요.
- #8 

### 4️⃣ 코드 설명 (Description)

- 브레이크포인트: 812px
  - 모바일 (≤ 812px): 슬라이드 사이드바 (오른쪽에서 슬라이드인)
  - 데스크탑 (> 812px): 중앙 네비 + 드롭다운
- 구현:
`// tailwind.config.jsscreens: { tablet: "813px" }`

- 모바일:
  - 중앙 네비 숨김
  - 햄버거 → 슬라이드 사이드바 + 오버레이
  - 프로젝트 메뉴 + 설정 메뉴 (구분선으로 분리)
- 데스크탑:
  - 중앙 네비 표시
  - 햄버거 → 설정 드롭다운만

### 5️⃣ 스크린샷 (Screenshots)
<img width="690" height="797" alt="스크린샷 2025-11-04 오후 4 20 50" src="https://github.com/user-attachments/assets/af557e84-fb36-4b5f-b826-051ac266dc43" />

