### PR TITLE
AD-10 feat: Insight page 구현

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -7,9 +7,25 @@ export const handlers = [
     return HttpResponse.json({ ok: true, time: new Date().toISOString() });
   }),
 
-  // 태스크 목록 조회
+  // 태스크 목록 조회 (타임스탬프 보정 포함)
   http.get("/api/tasks", () => {
-    return HttpResponse.json(mockTasks);
+    const seeded = mockTasks.map((t, idx) => {
+      // 기존 값이 있으면 유지, 없으면 기준일에서 -idx 일로 시드
+      const base = new Date();
+      base.setDate(base.getDate() - (mockTasks.length - idx));
+      const createdAt = t.createdAt ?? new Date(base.getTime()).toISOString();
+      const updatedAt =
+        t.updatedAt ??
+        new Date(base.getTime() + 3 * 60 * 60 * 1000).toISOString();
+      const qaApprovedAt =
+        t.status === "DONE" ? (t.qaApprovedAt ?? updatedAt) : t.qaApprovedAt;
+      return { ...t, createdAt, updatedAt, qaApprovedAt } as Task;
+    });
+    // mockTasks에 보정값 반영 (다음 요청 일관성)
+    for (let i = 0; i < mockTasks.length; i++) {
+      mockTasks[i] = { ...(seeded[i] as Task) };
+    }
+    return HttpResponse.json(seeded);
   }),
 
   // 태스크 상태 업데이트 (드래그 앤 드롭)
@@ -22,7 +38,14 @@ export const handlers = [
       return HttpResponse.json({ error: "Task not found" }, { status: 404 });
     }
 
-    mockTasks[taskIndex] = { ...mockTasks[taskIndex], ...body };
-    return HttpResponse.json(mockTasks[taskIndex]);
+    const now = new Date().toISOString();
+    const next: Task = {
+      ...mockTasks[taskIndex],
+      ...body,
+      updatedAt: now,
+      ...(body.status === "DONE" ? { qaApprovedAt: now } : {}),
+    } as Task;
+    mockTasks[taskIndex] = next;
+    return HttpResponse.json(next);
   }),
 ];

--- a/src/pages/insight/InsightPage.tsx
+++ b/src/pages/insight/InsightPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Calendar, Target } from "lucide-react";
+import { Calendar, CheckCheck } from "lucide-react";
 import KpiCard from "./components/KpiCard";
 import LinkCard from "./components/LinkCard";
 import CircularChart from "./components/CircularChart";
@@ -101,7 +101,7 @@ export default function InsightPage() {
           title="마지막 진행 날짜"
           value={loading ? "-" : formatDOffset(today.lastProgressAt)}
           sub={loading ? "-" : formatKoreanDate(today.lastProgressAt)}
-          icon={<Calendar className="h-12 w-12 text-black" />}
+          icon={<Calendar className="h-16 w-16 text-primary" />}
         />
         <KpiCard
           title="QA 통과 Task"
@@ -113,7 +113,7 @@ export default function InsightPage() {
                 ? `전날 대비 ${qaDelta.sign}${qaDelta.value}`
                 : "전날 대비 -"
           }
-          icon={<Target className="h-12 w-12 text-black" />}
+          icon={<CheckCheck className="h-16 w-16 text-primary" />}
         />
       </div>
 

--- a/src/pages/insight/InsightPage.tsx
+++ b/src/pages/insight/InsightPage.tsx
@@ -15,7 +15,6 @@ import {
 } from "./insightMetrics";
 import type { Task } from "../../types/task";
 import { useNavigate } from "@tanstack/react-router";
-import { Button } from "@/components/ui/button";
 
 export default function InsightPage() {
   const navigate = useNavigate();
@@ -62,25 +61,15 @@ export default function InsightPage() {
   const qaDelta = diffNumber(today.qaDoneCount, yesterday?.qaDoneCount ?? null);
 
   return (
-    <div className="min-h-screen bg-white px-24 py-10">
-      {/* Header with title, subtitle, and top-right button */}
-      <div className="relative mb-8 flex items-start justify-between">
-        <div className="flex-1 text-center">
-          <h1 className="text-4xl font-extrabold text-black">
-            프로젝트 인사이트
-          </h1>
-          <p className="mt-2 text-base text-black">
-            결과물은 로컬에서 확인하세요!
-          </p>
-        </div>
-        <div className="absolute right-0 top-0">
-          <Button
-            onClick={() => navigate({ to: "/task" })}
-            className="rounded-md bg-black px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
-          >
-            태스크 관리
-          </Button>
-        </div>
+    <div className="min-h-screen bg-white px-24 pt-14">
+      {/* Header with title and subtitle */}
+      <div className="mb-12 text-center">
+        <h1 className="text-5xl font-extrabold text-black">
+          프로젝트 인사이트
+        </h1>
+        <p className="mt-4 text-base text-black">
+          결과물은 로컬에서 확인하세요!
+        </p>
       </div>
 
       {/* First row: KPI Cards */}

--- a/src/pages/insight/InsightPage.tsx
+++ b/src/pages/insight/InsightPage.tsx
@@ -1,9 +1,116 @@
+import { useEffect, useMemo, useState } from "react";
+import KpiCard from "./components/KpiCard";
+import LinkCard from "./components/LinkCard";
+import {
+  computeMetrics,
+  diffNumber,
+  formatDOffset,
+  formatKoreanDate,
+  formatPercent,
+  getSnapshot,
+  saveDailySnapshot,
+  toKstDateKey,
+  getYesterdayKey,
+} from "./insightMetrics";
+import type { Task } from "../../types/task";
+import { useNavigate } from "@tanstack/react-router";
+
 export default function InsightPage() {
+  const navigate = useNavigate();
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // 태스크 불러오기
+  useEffect(() => {
+    const fetchTasks = async () => {
+      try {
+        const res = await fetch("/api/tasks");
+        const data = (await res.json()) as Task[];
+        setTasks(data);
+      } catch (e) {
+        console.error(e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchTasks();
+  }, []);
+
+  const { todayKey, yesterdayKey } = useMemo(() => {
+    return { todayKey: toKstDateKey(), yesterdayKey: getYesterdayKey() };
+  }, []);
+
+  // 지표 계산 및 스냅샷 저장/불러오기
+  const { today, yesterday } = useMemo(() => {
+    const m = computeMetrics(tasks);
+    const today = { dateKey: todayKey, ...m };
+    // 오늘 스냅샷 저장
+    if (!loading) {
+      saveDailySnapshot(today);
+    }
+    // 어제 스냅샷 조회
+    const y = getSnapshot(yesterdayKey) ?? null;
+    return { today, yesterday: y };
+  }, [tasks, loading, todayKey, yesterdayKey]);
+
+  const completionDelta = diffNumber(
+    Number(today.completionRate.toFixed(1)),
+    yesterday?.completionRate ?? null,
+  );
+  const qaDelta = diffNumber(today.qaDoneCount, yesterday?.qaDoneCount ?? null);
+
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold">인사이트</h1>
-      <p className="mt-4 text-gray-600">인사이트 페이지입니다.</p>
+      <h1 className="text-3xl font-extrabold">프로젝트 인사이트</h1>
+      <p className="mt-2 text-gray-600">결과물은 로컬에서 확인하세요!</p>
 
+      <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-3">
+        <KpiCard
+          title="Task 완료율"
+          value={loading ? "-" : formatPercent(today.completionRate, 0)}
+          sub={
+            loading
+              ? "전일 대비 -"
+              : completionDelta
+                ? `전일 대비 ${completionDelta.sign}${completionDelta.value}%`
+                : "전일 대비 -"
+          }
+        />
+        <KpiCard
+          title="마지막 진행 날짜"
+          value={loading ? "-" : formatDOffset(today.lastProgressAt)}
+          sub={loading ? "-" : formatKoreanDate(today.lastProgressAt)}
+        />
+        <KpiCard
+          title="QA 통과 Task"
+          value={loading ? "-" : today.qaDoneCount}
+          sub={
+            loading
+              ? "전일 대비 -"
+              : qaDelta
+                ? `전일 대비 ${qaDelta.sign}${qaDelta.value}`
+                : "전일 대비 -"
+          }
+        />
+      </div>
+
+      <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-3">
+        <LinkCard
+          subtitle="PRD, SRS, User Story"
+          title="문서 보러가기"
+          onClick={() => navigate({ to: "/document" })}
+        />
+        <LinkCard
+          subtitle="AI와 채팅하며"
+          title="Task 추가하기"
+          onClick={() => navigate({ to: "/task?new=1" })}
+        />
+        <LinkCard
+          subtitle="서비스 이용방법"
+          title="How To Use"
+          onClick={() => navigate({ to: "/guide" })}
+        />
+      </div>
     </div>
   );
 }

--- a/src/pages/insight/InsightPage.tsx
+++ b/src/pages/insight/InsightPage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
-import { CheckCircle2, Calendar, Target } from "lucide-react";
+import { Calendar, Target } from "lucide-react";
 import KpiCard from "./components/KpiCard";
 import LinkCard from "./components/LinkCard";
+import CircularChart from "./components/CircularChart";
 import {
   computeMetrics,
   diffNumber,
@@ -84,7 +85,17 @@ export default function InsightPage() {
                 ? `전날 대비 ${completionDelta.sign}${completionDelta.value}%`
                 : "전날 대비 -"
           }
-          icon={<CheckCircle2 className="h-12 w-12 text-black" />}
+          icon={
+            loading ? (
+              <div className="h-16 w-16" />
+            ) : (
+              <CircularChart
+                value={Math.round(today.completionRate)}
+                size={64}
+                strokeWidth={6}
+              />
+            )
+          }
         />
         <KpiCard
           title="마지막 진행 날짜"
@@ -116,7 +127,9 @@ export default function InsightPage() {
         <LinkCard
           subtitle="AI와 채팅하며"
           title="Task 추가하기"
-          onClick={() => navigate({ to: "/task?new=1" })}
+          onClick={() => {
+            window.location.href = "/task?new=1";
+          }}
         />
         <LinkCard
           subtitle="서비스 이용방법"

--- a/src/pages/insight/InsightPage.tsx
+++ b/src/pages/insight/InsightPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { CheckCircle2, Calendar, Target } from "lucide-react";
 import KpiCard from "./components/KpiCard";
 import LinkCard from "./components/LinkCard";
 import {
@@ -14,6 +15,7 @@ import {
 } from "./insightMetrics";
 import type { Task } from "../../types/task";
 import { useNavigate } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
 
 export default function InsightPage() {
   const navigate = useNavigate();
@@ -60,41 +62,63 @@ export default function InsightPage() {
   const qaDelta = diffNumber(today.qaDoneCount, yesterday?.qaDoneCount ?? null);
 
   return (
-    <div className="p-6">
-      <h1 className="text-3xl font-extrabold">프로젝트 인사이트</h1>
-      <p className="mt-2 text-gray-600">결과물은 로컬에서 확인하세요!</p>
+    <div className="min-h-screen bg-white px-24 py-10">
+      {/* Header with title, subtitle, and top-right button */}
+      <div className="relative mb-8 flex items-start justify-between">
+        <div className="flex-1 text-center">
+          <h1 className="text-4xl font-extrabold text-black">
+            프로젝트 인사이트
+          </h1>
+          <p className="mt-2 text-base text-black">
+            결과물은 로컬에서 확인하세요!
+          </p>
+        </div>
+        <div className="absolute right-0 top-0">
+          <Button
+            onClick={() => navigate({ to: "/task" })}
+            className="rounded-md bg-black px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+          >
+            태스크 관리
+          </Button>
+        </div>
+      </div>
 
-      <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-3">
+      {/* First row: KPI Cards */}
+      <div className="mb-6 grid grid-cols-1 gap-4 md:grid-cols-3 md:items-stretch">
         <KpiCard
           title="Task 완료율"
           value={loading ? "-" : formatPercent(today.completionRate, 0)}
           sub={
             loading
-              ? "전일 대비 -"
+              ? "전날 대비 -"
               : completionDelta
-                ? `전일 대비 ${completionDelta.sign}${completionDelta.value}%`
-                : "전일 대비 -"
+                ? `전날 대비 ${completionDelta.sign}${completionDelta.value}%`
+                : "전날 대비 -"
           }
+          icon={<CheckCircle2 className="h-12 w-12 text-black" />}
         />
         <KpiCard
           title="마지막 진행 날짜"
           value={loading ? "-" : formatDOffset(today.lastProgressAt)}
           sub={loading ? "-" : formatKoreanDate(today.lastProgressAt)}
+          icon={<Calendar className="h-12 w-12 text-black" />}
         />
         <KpiCard
           title="QA 통과 Task"
           value={loading ? "-" : today.qaDoneCount}
           sub={
             loading
-              ? "전일 대비 -"
+              ? "전날 대비 -"
               : qaDelta
-                ? `전일 대비 ${qaDelta.sign}${qaDelta.value}`
-                : "전일 대비 -"
+                ? `전날 대비 ${qaDelta.sign}${qaDelta.value}`
+                : "전날 대비 -"
           }
+          icon={<Target className="h-12 w-12 text-black" />}
         />
       </div>
 
-      <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-3">
+      {/* Second row: Link Cards */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3 md:items-stretch">
         <LinkCard
           subtitle="PRD, SRS, User Story"
           title="문서 보러가기"

--- a/src/pages/insight/components/CircularChart.tsx
+++ b/src/pages/insight/components/CircularChart.tsx
@@ -1,0 +1,49 @@
+interface CircularChartProps {
+  value: number; // 0-100
+  size?: number;
+  strokeWidth?: number;
+}
+
+export default function CircularChart({
+  value,
+  size = 48,
+  strokeWidth = 4,
+}: CircularChartProps) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (value / 100) * circumference;
+
+  return (
+    <div className="relative" style={{ width: size, height: size }}>
+      <svg width={size} height={size} className="transform -rotate-90">
+        {/* Background circle */}
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          fill="none"
+          className="text-gray-200"
+        />
+        {/* Progress circle */}
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          fill="none"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+          className="text-primary transition-all duration-300"
+        />
+      </svg>
+      {/* Center text */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        <span className="text-sm font-bold text-primary">{value}%</span>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/insight/components/KpiCard.tsx
+++ b/src/pages/insight/components/KpiCard.tsx
@@ -11,7 +11,7 @@ export default function KpiCard({ title, value, sub, icon }: KpiCardProps) {
   return (
     <div
       className="grid h-full min-h-[200px] gap-4 rounded-lg border border-gray-300 bg-white p-6"
-      style={{ gridTemplateColumns: "1fr auto" }}
+      style={{ gridTemplateColumns: "3fr 1fr" }}
     >
       <div className="flex flex-col flex-1">
         <div className="text-xl font-semibold text-black">{title}</div>
@@ -27,7 +27,7 @@ export default function KpiCard({ title, value, sub, icon }: KpiCardProps) {
         </div>
       </div>
       {icon && (
-        <div className="flex items-center justify-end flex-shrink-0">
+        <div className="flex items-center justify-center flex-shrink-0">
           {icon}
         </div>
       )}

--- a/src/pages/insight/components/KpiCard.tsx
+++ b/src/pages/insight/components/KpiCard.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from "react";
+
+interface KpiCardProps {
+  title: string;
+  value: ReactNode;
+  sub?: ReactNode;
+  icon?: ReactNode;
+}
+
+export default function KpiCard({ title, value, sub, icon }: KpiCardProps) {
+  return (
+    <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+      <div className="flex items-start justify-between">
+        <div className="text-sm font-medium text-gray-600">{title}</div>
+        {icon}
+      </div>
+      <div className="mt-3 text-4xl font-extrabold tracking-tight">{value}</div>
+      {sub ? <div className="mt-2 text-sm text-gray-500">{sub}</div> : null}
+    </div>
+  );
+}

--- a/src/pages/insight/components/KpiCard.tsx
+++ b/src/pages/insight/components/KpiCard.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 interface KpiCardProps {
   title: string;
@@ -9,13 +9,28 @@ interface KpiCardProps {
 
 export default function KpiCard({ title, value, sub, icon }: KpiCardProps) {
   return (
-    <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-      <div className="flex items-start justify-between">
-        <div className="text-sm font-medium text-gray-600">{title}</div>
-        {icon}
+    <div
+      className="grid h-full min-h-[200px] gap-4 rounded-lg border border-gray-300 bg-white p-6"
+      style={{ gridTemplateColumns: "1fr auto" }}
+    >
+      <div className="flex flex-col flex-1">
+        <div className="text-xl font-semibold text-black">{title}</div>
+        <div className="flex flex-1 flex-col justify-center">
+          <div className="text-5xl font-extrabold tracking-tight text-black">
+            {value}
+          </div>
+          {sub ? (
+            <div className="mt-2 text-sm font-normal text-primary">{sub}</div>
+          ) : (
+            <div className="mt-2"></div>
+          )}
+        </div>
       </div>
-      <div className="mt-3 text-4xl font-extrabold tracking-tight">{value}</div>
-      {sub ? <div className="mt-2 text-sm text-gray-500">{sub}</div> : null}
+      {icon && (
+        <div className="flex items-center justify-end flex-shrink-0">
+          {icon}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/insight/components/LineChart.tsx
+++ b/src/pages/insight/components/LineChart.tsx
@@ -1,0 +1,73 @@
+interface LineChartProps {
+  data: number[]; // 최근 5일간의 데이터 (오래된 순서부터)
+  width?: number;
+  height?: number;
+}
+
+export default function LineChart({
+  data,
+  width = 64,
+  height = 48,
+}: LineChartProps) {
+  if (data.length === 0) return null;
+
+  const padding = 8;
+  const chartWidth = width - padding * 2;
+  const chartHeight = height - padding * 2;
+
+  // 데이터 정규화 (0-100 범위)
+  const maxValue = Math.max(...data, 1); // 최소값 1로 설정하여 0으로 나누기 방지
+  const normalizedData = data.map((value) => (value / maxValue) * 100);
+
+  // 좌표 계산
+  const points = normalizedData.map((value, index) => {
+    const x = padding + (chartWidth / (data.length - 1 || 1)) * index;
+    const y = padding + chartHeight - (value / 100) * chartHeight;
+    return { x, y };
+  });
+
+  // SVG path 생성
+  const pathData = points
+    .map((point, index) => `${index === 0 ? "M" : "L"} ${point.x} ${point.y}`)
+    .join(" ");
+
+  return (
+    <div className="relative" style={{ width, height }}>
+      <svg width={width} height={height} className="overflow-visible">
+        {/* 그리드 라인 (선택사항) */}
+        {/* <line
+          x1={padding}
+          y1={padding + chartHeight}
+          x2={padding + chartWidth}
+          y2={padding + chartHeight}
+          stroke="currentColor"
+          strokeWidth="1"
+          className="text-gray-200"
+        /> */}
+
+        {/* 꺾은선 */}
+        <path
+          d={pathData}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="text-primary"
+        />
+
+        {/* 점 */}
+        {points.map((point, index) => (
+          <circle
+            key={index}
+            cx={point.x}
+            cy={point.y}
+            r="2"
+            fill="currentColor"
+            className="text-primary"
+          />
+        ))}
+      </svg>
+    </div>
+  );
+}

--- a/src/pages/insight/components/LinkCard.tsx
+++ b/src/pages/insight/components/LinkCard.tsx
@@ -1,4 +1,5 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
+import { ChevronRight } from "lucide-react";
 
 interface LinkCardProps {
   title: string;
@@ -17,20 +18,21 @@ export default function LinkCard({
     <button
       type="button"
       onClick={onClick}
-      className="group flex w-full items-center justify-between rounded-2xl border border-gray-200 bg-white p-6 text-left shadow-sm transition hover:shadow-md"
+      className="flex h-full min-h-[200px] w-full flex-col rounded-lg border border-gray-300 bg-white pt-6 pb-8 px-4 text-left"
     >
-      <div>
-        {subtitle ? (
-          <div className="text-xs font-semibold tracking-wide text-gray-500">
-            {subtitle}
-          </div>
-        ) : null}
-        <div className="mt-1 text-2xl font-extrabold tracking-tight">
+      <div className="flex items-start justify-between">
+        <div className="text-xl ml-2 font-normal text-black">{subtitle}</div>
+      </div>
+      <div
+        className="mt-auto ml-2 grid items-center gap-4"
+        style={{ gridTemplateColumns: "1fr auto" }}
+      >
+        <div className="text-4xl font-extrabold tracking-tight text-black">
           {title}
         </div>
-      </div>
-      <div className="text-gray-400 group-hover:text-gray-600">
-        {right ?? "›"}
+        <div className="flex justify-end flex-shrink-0">
+          {right ?? <ChevronRight className="h-8 w-8 text-black" />}
+        </div>
       </div>
     </button>
   );

--- a/src/pages/insight/components/LinkCard.tsx
+++ b/src/pages/insight/components/LinkCard.tsx
@@ -18,7 +18,7 @@ export default function LinkCard({
     <button
       type="button"
       onClick={onClick}
-      className="flex h-full min-h-[200px] w-full flex-col rounded-lg border border-gray-300 bg-white pt-6 pb-8 px-4 text-left"
+      className="flex h-full min-h-[200px] w-full flex-col rounded-lg border border-gray-300 bg-white pt-6 pb-8 px-4 text-left hover:bg-gray-100"
     >
       <div className="flex items-start justify-between">
         <div className="text-xl ml-2 font-normal text-black">{subtitle}</div>

--- a/src/pages/insight/components/LinkCard.tsx
+++ b/src/pages/insight/components/LinkCard.tsx
@@ -1,0 +1,37 @@
+import { ReactNode } from "react";
+
+interface LinkCardProps {
+  title: string;
+  subtitle?: string;
+  right?: ReactNode;
+  onClick?: () => void;
+}
+
+export default function LinkCard({
+  title,
+  subtitle,
+  right,
+  onClick,
+}: LinkCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex w-full items-center justify-between rounded-2xl border border-gray-200 bg-white p-6 text-left shadow-sm transition hover:shadow-md"
+    >
+      <div>
+        {subtitle ? (
+          <div className="text-xs font-semibold tracking-wide text-gray-500">
+            {subtitle}
+          </div>
+        ) : null}
+        <div className="mt-1 text-2xl font-extrabold tracking-tight">
+          {title}
+        </div>
+      </div>
+      <div className="text-gray-400 group-hover:text-gray-600">
+        {right ?? "›"}
+      </div>
+    </button>
+  );
+}

--- a/src/pages/insight/insightMetrics.ts
+++ b/src/pages/insight/insightMetrics.ts
@@ -134,5 +134,6 @@ export function formatKoreanDate(iso?: string): string {
     month: "long",
     day: "numeric",
   });
+  // Format: "2025년 9월 22일"
   return f.format(d);
 }

--- a/src/pages/insight/insightMetrics.ts
+++ b/src/pages/insight/insightMetrics.ts
@@ -79,6 +79,35 @@ export function getSnapshot(dateKey: string): InsightMetricsSnapshot | null {
   }
 }
 
+// 최근 N일간의 일자별 태스크 활동 수 계산
+export function getRecentActivityCounts(
+  tasks: Task[],
+  days: number = 5,
+): number[] {
+  const counts: number[] = [];
+  const today = new Date();
+
+  for (let i = days - 1; i >= 0; i--) {
+    const targetDate = addDays(today, -i);
+    const targetDateKey = toKstDateKey(targetDate);
+
+    // 해당 날짜에 업데이트된 태스크 수 계산
+    const count = tasks.filter((task) => {
+      const taskWithTimestamps = task as unknown as TaskWithTimestamps;
+      if (!taskWithTimestamps.updatedAt) return false;
+
+      const taskDate = new Date(taskWithTimestamps.updatedAt);
+      const taskDateKey = toKstDateKey(taskDate);
+
+      return taskDateKey === targetDateKey;
+    }).length;
+
+    counts.push(count);
+  }
+
+  return counts;
+}
+
 // 숫자 증감 도우미(전일 대비)
 export function diffNumber(
   current: number,

--- a/src/pages/insight/insightMetrics.ts
+++ b/src/pages/insight/insightMetrics.ts
@@ -1,0 +1,138 @@
+// 인사이트 대시보드: 지표 계산 및 일자별 스냅샷 유틸리티
+import type { Task } from "../../types/task";
+
+// 내부적으로 선택 타임스탬프를 허용하기 위한 보조 타입
+interface TaskWithTimestamps extends Task {
+  createdAt?: string;
+  updatedAt?: string;
+  qaApprovedAt?: string;
+}
+
+export interface InsightMetricsSnapshot {
+  dateKey: string; // KST YYYYMMDD
+  completionRate: number; // 0~100
+  qaDoneCount: number; // DONE 개수
+  lastProgressAt?: string; // ISO 문자열
+}
+
+const STORAGE_PREFIX = "insight:metrics";
+
+// KST 기준 일자 키(YYYYMMDD) 생성
+export function toKstDateKey(date: Date = new Date()): string {
+  const formatter = new Intl.DateTimeFormat("sv-SE", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  return formatter.format(date).replaceAll("-", "");
+}
+
+export function addDays(date: Date, days: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+export function getYesterdayKey(base: Date = new Date()): string {
+  return toKstDateKey(addDays(base, -1));
+}
+
+// 태스크 배열에서 핵심 지표 계산
+export function computeMetrics(
+  tasks: Task[],
+): Omit<InsightMetricsSnapshot, "dateKey"> {
+  const totalTasks = tasks.length;
+  const doneCount = tasks.filter((t) => t.status === "DONE").length;
+  const completionRate = totalTasks === 0 ? 0 : (doneCount / totalTasks) * 100;
+
+  // 가장 최근 변경 시각: updatedAt 최대값
+  const lastUpdated = tasks
+    .map((t) => (t as unknown as TaskWithTimestamps).updatedAt)
+    .filter(Boolean)
+    .map((v) => new Date(v as string).getTime());
+  const maxTs = lastUpdated.length ? Math.max(...lastUpdated) : undefined;
+
+  return {
+    completionRate,
+    qaDoneCount: doneCount,
+    lastProgressAt: maxTs ? new Date(maxTs).toISOString() : undefined,
+  };
+}
+
+// 일자별 스냅샷 저장/조회
+export function saveDailySnapshot(snapshot: InsightMetricsSnapshot): void {
+  try {
+    const key = `${STORAGE_PREFIX}:${snapshot.dateKey}`;
+    localStorage.setItem(key, JSON.stringify(snapshot));
+  } catch {
+    // storage 불가 환경은 무시
+  }
+}
+
+export function getSnapshot(dateKey: string): InsightMetricsSnapshot | null {
+  try {
+    const raw = localStorage.getItem(`${STORAGE_PREFIX}:${dateKey}`);
+    return raw ? (JSON.parse(raw) as InsightMetricsSnapshot) : null;
+  } catch {
+    return null;
+  }
+}
+
+// 숫자 증감 도우미(전일 대비)
+export function diffNumber(
+  current: number,
+  previous?: number | null,
+): {
+  value: number;
+  sign: "+" | "-" | "=";
+} | null {
+  if (previous === undefined || previous === null) return null;
+  const delta = current - previous;
+  if (delta === 0) return { value: 0, sign: "=" };
+  return { value: Math.abs(delta), sign: delta > 0 ? "+" : "-" };
+}
+
+// 마지막 진행 날짜를 D±N 포맷으로 출력(KST, 일 단위)
+export function formatDOffset(lastProgressAt?: string): string {
+  if (!lastProgressAt) return "-";
+  const nowKstKey = toKstDateKey();
+  const lastKey = toKstDateKey(new Date(lastProgressAt));
+
+  const yyyy = Number(nowKstKey.slice(0, 4));
+  const mm = Number(nowKstKey.slice(4, 6)) - 1;
+  const dd = Number(nowKstKey.slice(6, 8));
+  const today = new Date(Date.UTC(yyyy, mm, dd));
+
+  const lyyyy = Number(lastKey.slice(0, 4));
+  const lmm = Number(lastKey.slice(4, 6)) - 1;
+  const ldd = Number(lastKey.slice(6, 8));
+  const last = new Date(Date.UTC(lyyyy, lmm, ldd));
+
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const diffDays = Math.floor((today.getTime() - last.getTime()) / msPerDay);
+  if (diffDays <= 0) return "D-Day";
+  return `D+${diffDays}`;
+}
+
+export function formatPercent(value: number, digits = 0): string {
+  return `${value.toFixed(digits)}%`;
+}
+
+export function formatSigned(value: number, unit: string = ""): string {
+  const sign = value > 0 ? "+" : value < 0 ? "-" : "";
+  const abs = Math.abs(value);
+  return `${sign}${abs}${unit}`;
+}
+
+export function formatKoreanDate(iso?: string): string {
+  if (!iso) return "-";
+  const d = new Date(iso);
+  const f = new Intl.DateTimeFormat("ko-KR", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+  return f.format(d);
+}

--- a/src/pages/task/TaskPage.tsx
+++ b/src/pages/task/TaskPage.tsx
@@ -33,6 +33,18 @@ export default function TaskPage() {
     fetchTasks();
   }, []);
 
+  // URL 쿼리로 진입 시 추가 모달 자동 오픈 (?new=1)
+  useEffect(() => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get("new")) {
+        setIsModalOpen(true);
+      }
+    } catch {
+      // window 사용 불가 환경은 무시
+    }
+  }, []);
+
   // 태스크 상태 업데이트
   const handleTaskUpdate = async (
     taskId: string,

--- a/src/pages/task/TaskPage.tsx
+++ b/src/pages/task/TaskPage.tsx
@@ -222,14 +222,11 @@ export default function TaskPage() {
 
   return (
     <div className="min-h-screen p-8">
-      {/* 제목 및 인사이트 버튼 */}
-      <div className="flex items-center justify-between mb-6">
+      {/* 제목 */}
+      <div className="mb-6">
         <h1 className="text-3xl font-bold text-customBlack">
           종합설계프로젝트 1팀 의 대시보드
         </h1>
-        <button className="px-6 py-2 bg-customBlack text-white rounded-lg hover:bg-opacity-90 transition-colors">
-          인사이트 보기
-        </button>
       </div>
 
       {/* 검색바 + 통계 + 컬럼 테두리 박스 */}

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -11,6 +11,10 @@ export interface Task {
   priority: number; // 중요도 (0-10)
   content?: string; // 마크다운 상세 내용
   taskCode?: string; // 작업 코드 (예: "T-001")
+  // 선택 타임스탬프 필드 (인사이트/히스토리용)
+  createdAt?: string;
+  updatedAt?: string;
+  qaApprovedAt?: string; // DONE 전환 시점
 }
 
 export interface TaskStats {


### PR DESCRIPTION
### 1️⃣ PR 타입 (PR Type)

<!-- 해당하는 곳에 `x`를 표시해주세요. -->

- [x] ✨ feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [ ] 🎨 style: 코드 스타일 변경 (포맷팅, 세미콜론 추가 등)
- [ ] chore: 빌드 스크립트 수정, 패키지 매니저 설정 변경 등

### 2️⃣ 변경 사항 (Changes)

- 인사이트 페이지 구현: 프로젝트 지표를 시각화하는 대시보드 페이지 추가

### 3️⃣ 관련 이슈 (Related Issues)

- 관련 이슈 번호를 작성해주세요.
- #10 

### 4️⃣ 코드 설명 (Description)

- KPI 카드: Task 완료율(원형 차트), 마지막 진행 날짜, QA 통과 Task 지표 표시
- 링크 카드: 문서 보러가기, Task 추가하기, How To Use 네비게이션
- 일자별 스냅샷: localStorage를 사용한 일자별 지표 데이터 저장 및 조회
- 전날 대비 비교: 전날 데이터와 비교하여 증감률 계산 및 표시
- 반응형 레이아웃: 2x3 그리드 레이아웃으로 카드 배치

### 5️⃣ 스크린샷 (Screenshots)
<img width="1470" height="872" alt="스크린샷 2025-11-05 오후 3 10 58" src="https://github.com/user-attachments/assets/e4e08fc3-7428-4922-a4c0-037a53130ccd" />

